### PR TITLE
FIX: copyfile()/symlinks on Linux, Matlab < R2020a

### DIFF
--- a/spm_BIDS_App.m
+++ b/spm_BIDS_App.m
@@ -224,7 +224,7 @@ if strncmp('participant',BIDS_App.level,11) && ~isempty(BIDS_App.participants)
         %------------------------------------------------------------------
         for s=1:numel(BIDS_App.participants)
             %
-            % Datasets may managed data with symlinks (e.g. datalad/git-annex)
+            % Datasets may be managed with symlinks (e.g. datalad/git-annex)
             %
             % Prior to Matlab 2020, copyfile() on Linux will not dereference
             % the symlink, which can easily break if the target is relative.

--- a/spm_BIDS_App.m
+++ b/spm_BIDS_App.m
@@ -223,10 +223,27 @@ if strncmp('participant',BIDS_App.level,11) && ~isempty(BIDS_App.participants)
         %-Copy participants' data
         %------------------------------------------------------------------
         for s=1:numel(BIDS_App.participants)
-            %fprintf('Temporary directory: %s\n',...
-            %    fullfile(BIDS_App.tmpdir,BIDS_App.participants{s}));
-            sts = copyfile(fullfile(BIDS_App.dir,BIDS_App.participants{s}),...
-                fullfile(BIDS_App.tmpdir,BIDS_App.participants{s}));
+            %
+            % Datasets may managed data with symlinks (e.g. datalad/git-annex)
+            %
+            % Prior to Matlab 2020, copyfile() on Linux will not dereference
+            % the symlink, which can easily break if the target is relative.
+            % To save space keeping the symblic would be the better choice, but
+            % it's much harder to determine the correct location for all
+            % platforms, so we resort to cp -L in that special case and always
+            % dereference.
+            %
+            %   https://www.mathworks.com/help/matlab/ref/copyfile.html
+            %
+            matlab_ver = str2num(erase(ver('MATLAB').('Version'), '.'));
+            if isunix && matlab_ver <= 98 % We should always be on Linux, but still
+                sts = system(sprintf('cp -rL "%s" "%s"', fullfile(BIDS_App.dir, BIDS_App.participants{s}),...
+                    fullfile(BIDS_App.tmpdir, BIDS_App.participants{s})));
+                sts = ~ sts; % exit semantic is inverted in shell
+            else
+                sts = copyfile(fullfile(BIDS_App.dir,BIDS_App.participants{s}),...
+                    fullfile(BIDS_App.tmpdir,BIDS_App.participants{s}));
+            end
             if ~sts
                 error('Data could not be temporarily copied.');
             end


### PR DESCRIPTION
I tried running the SPM container on `ds000001` which I pulled with datalad. It turns out that datalad is using symbolic links for the images in `anat/` and `func/` etc pointing to a `.git-annex` folder two levels above.

Unfortunately, `copyfile()` on [Linux with Matlab <= 2019b](https://www.mathworks.com/help/matlab/ref/copyfile.html) does not dereference the file and when SPM is copying a relative symlink to the tmp/output folder, the link breaks.

This PR is checking if we are on Linux on Matlab < 2020a (with an ugly versioncmp hack) and uses `system('cp -rL...')` instead of `copyfile()`.

Also, as I mention in the comment, it would probably be much nicer to keep the symbolic links for all platforms, but I'm having a hard time coming up with a portable solution for that. And I'm also not entirely sure this is compatible with SPM's behavior (would it modify source files in that case?)