### PR TITLE
[WIP] Use different base image containing MCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,6 @@
-FROM bids/base_validator
+FROM bids/matlab-compiler-runtime:9.7
 
 MAINTAINER Guillaume Flandin <g.flandin@ucl.ac.uk>
-
-# Update system
-RUN apt-get -qq update && apt-get -qq install -y \
-    unzip \
-    xorg \
-    wget && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install MATLAB MCR
-ENV MATLAB_VERSION R2019b
-ENV MATLAB_UPDATE 5
-RUN mkdir /opt/mcr_install && \
-    mkdir /opt/mcr && \
-    wget -P /opt/mcr_install https://ssd.mathworks.com/supportfiles/downloads/${MATLAB_VERSION}/Release/${MATLAB_UPDATE}/deployment_files/installer/complete/glnxa64/MATLAB_Runtime_${MATLAB_VERSION}_Update_${MATLAB_UPDATE}_glnxa64.zip && \
-    unzip -q /opt/mcr_install/MATLAB_Runtime_${MATLAB_VERSION}_Update_${MATLAB_UPDATE}_glnxa64.zip -d /opt/mcr_install && \
-    /opt/mcr_install/install -destinationFolder /opt/mcr -agreeToLicense yes -mode silent && \
-    rm -rf /opt/mcr_install /tmp/*
-
-# Configure environment
-ENV MCR_VERSION v97
-ENV LD_LIBRARY_PATH /opt/mcr/${MCR_VERSION}/runtime/glnxa64:/opt/mcr/${MCR_VERSION}/bin/glnxa64:/opt/mcr/${MCR_VERSION}/sys/os/glnxa64:/opt/mcr/${MCR_VERSION}/sys/opengl/lib/glnxa64
-ENV MCR_INHIBIT_CTF_LOCK 1
 
 # Install SPM Standalone
 ENV SPM_VERSION 12


### PR DESCRIPTION
I am in the process of cleaning up the [base MCR](https://github.com/BIDS-Apps/matlab-compiler-runtime) image a little bit, so you can directly base this image on it. Or is there a reason why you based it on `bids_validator` except that the MCR image is out of date?