### PR TITLE
[BUG] only one el in BIDS.participants.meta

### DIFF
--- a/spm_BIDS_App.m
+++ b/spm_BIDS_App.m
@@ -260,7 +260,13 @@ BIDS.subjects = BIDS.subjects(idx);
 if ~isempty(BIDS.participants)
     idx = ismember(BIDS.participants.participant_id,BIDS_App.participants);
     for fn=fieldnames(BIDS.participants)'
-        BIDS.participants.(char(fn)) = BIDS.participants.(char(fn))(idx);
+        replace = BIDS.participants.(char(fn));
+        % BIDS.participants.meta is 1x1. other fields are 1xN
+        if(length(replace) < length(idx))
+           warning('%s: idx len %d > number of values %d; ignored', char(fn), length(idx), length(replace))
+           continue
+        end
+        BIDS.participants.(char(fn)) = replace(idx);
     end
 end
 

--- a/spm_BIDS_App.m
+++ b/spm_BIDS_App.m
@@ -265,7 +265,7 @@ if ~isempty(BIDS.participants)
         if(length(replace) < length(idx))
            warning('%s: idx len %d > number of values %d; ignored', char(fn), length(idx), length(replace))
            continue
-        end
+        end 
         BIDS.participants.(char(fn)) = replace(idx);
     end
 end


### PR DESCRIPTION
This patch skips any field with too few values when narrowing `BIDS.participant` to command-line specified labels.

But maybe skipping `meta` specifically is a safer approach. 

The index issues show up on issue #27, replacing BIDS.participants  with error
> The logical indices contain a true value outside of the array bounds.

likely because the meta field is always(?) an array of length 1. No error if the label is also the first participant in the BIDS structure.

```
BIDS.participants.meta

  struct with fields:

    participant_id: [1x1 struct]
               age: [1x1 struct]
               sex: [1x1 struct]
             group: [1x1 struct]
             
  
  BIDS.participants.meta.participant_id(1).Description, 
    'Participant identifier'

BIDS.participants.meta.sex(1).Description,
    'self-rated by participant, M for male/F for female (TODO: verify)'             
```

FWIW, I think these are populated from our `participants.json` file

```
jq . BIDS/participants.json 
{
  "participant_id": {
    "Description": "Participant identifier"
  },
  "age": {
    "Description": "Age in years (TODO - verify) as in the initial session, might not be correct for other sessions"
  },
  "sex": {
    "Description": "self-rated by participant, M for male/F for female (TODO: verify)"
  },
  "group": {
    "Description": "(TODO: adjust - by default everyone is in control group)"
  }
}

```